### PR TITLE
Fix/abstract task thread

### DIFF
--- a/src/os/posix/include/AbstractTask.tpp
+++ b/src/os/posix/include/AbstractTask.tpp
@@ -9,9 +9,9 @@ AbstractTask<stackSize>::AbstractTask(const char* taskName, UBaseType_t priority
 
 template <unsigned int stackSize>
 AbstractTask<stackSize>::~AbstractTask() {
-    /*if (m_taskRunning) {
+    //if (m_taskRunning) {
         m_thread.join();
-    }*/
+    //}
 }
 
 template <unsigned int stackSize>

--- a/src/os/posix/include/AbstractTask.tpp
+++ b/src/os/posix/include/AbstractTask.tpp
@@ -9,7 +9,9 @@ AbstractTask<stackSize>::AbstractTask(const char* taskName, UBaseType_t priority
 
 template <unsigned int stackSize>
 AbstractTask<stackSize>::~AbstractTask() {
-    m_thread.join();
+    if (m_taskRunning) {
+        m_thread.join();
+    }
 }
 
 template <unsigned int stackSize>

--- a/src/os/posix/include/AbstractTask.tpp
+++ b/src/os/posix/include/AbstractTask.tpp
@@ -9,9 +9,9 @@ AbstractTask<stackSize>::AbstractTask(const char* taskName, UBaseType_t priority
 
 template <unsigned int stackSize>
 AbstractTask<stackSize>::~AbstractTask() {
-    if (m_taskRunning) {
+    /*if (m_taskRunning) {
         m_thread.join();
-    }
+    }*/
 }
 
 template <unsigned int stackSize>

--- a/src/os/posix/include/AbstractTask.tpp
+++ b/src/os/posix/include/AbstractTask.tpp
@@ -38,7 +38,7 @@ void AbstractTask<stackSize>::wrapper(void* params) {
 
 template <unsigned int stackSize>
 TaskHandle_t AbstractTask<stackSize>::getTaskHandle() {
-    return 0;
+    return m_thread;
 }
 
 #endif // ABSTRACTTASK_TPP

--- a/src/os/posix/include/AbstractTask.tpp
+++ b/src/os/posix/include/AbstractTask.tpp
@@ -9,9 +9,9 @@ AbstractTask<stackSize>::AbstractTask(const char* taskName, UBaseType_t priority
 
 template <unsigned int stackSize>
 AbstractTask<stackSize>::~AbstractTask() {
-    //if (m_taskRunning) {
+    if (m_taskRunning) {
         m_thread.join();
-    //}
+    }
 }
 
 template <unsigned int stackSize>

--- a/src/os/posix/include/OSMacros.h
+++ b/src/os/posix/include/OSMacros.h
@@ -5,7 +5,7 @@
 #include <thread>
 
 typedef unsigned long UBaseType_t;
-typedef std::thread TaskHandle_t;
+typedef std::thread& TaskHandle_t;
 typedef void (*TaskFunction_t)(void*);
 
 #define configMINIMAL_STACK_SIZE 1

--- a/src/os/posix/include/OSMacros.h
+++ b/src/os/posix/include/OSMacros.h
@@ -2,9 +2,10 @@
 #define __MACROS_H__
 
 #include <stdint.h>
+#include <thread>
 
 typedef unsigned long UBaseType_t;
-typedef uint8_t TaskHandle_t;
+typedef std::thread TaskHandle_t;
 typedef void (*TaskFunction_t)(void*);
 
 #define configMINIMAL_STACK_SIZE 1


### PR DESCRIPTION
Reason for changes: allows unit testing of classes using the abstract task.

Added retrieving of thread handle and added check on joining